### PR TITLE
feat: Filtering for user property search

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,6 @@ import { Plugin, PluginEvent, PluginMeta, Properties, RetryError } from '@postho
 import crypto from 'crypto'
 import fetch, { RequestInit, Response } from 'node-fetch'
 
-
 export type FetchBraze = (
     endpoint: string,
     options: Partial<RequestInit>,
@@ -19,16 +18,9 @@ type BrazePlugin = Plugin<{
     config: {
         brazeEndpoint: 'US-01' | 'US-02' | 'US-03' | 'US-04' | 'US-05' | 'US-06' | 'US-08' | 'EU-01' | 'EU-02'
         apiKey: string
-        importCampaigns: BooleanChoice
-        importCanvases: BooleanChoice
-        importCustomEvents: BooleanChoice
-        importFeeds: BooleanChoice
-        importKPIs: BooleanChoice
-        importSegments: BooleanChoice
-        importSessions: BooleanChoice
         eventsToExport: string
         userPropertiesToExport: string
-        importUserAttributesInAllEvents: BooleanChoice
+        eventsToExportUserPropertiesFrom: string
     }
 }>
 
@@ -168,8 +160,7 @@ const _generateBrazeRequestBody = (pluginEvent: PluginEvent, meta: BrazeMeta): B
         return filtered
     }, {} as Properties)
 
-    const shouldImportAttributes =
-        meta.config.importUserAttributesInAllEvents === 'Yes' || meta.config.eventsToExport?.split(',').includes(event)
+    const shouldImportAttributes = meta.config.eventsToExportUserPropertiesFrom?.split(',').includes(event)
 
     const attributes: Array<BrazeAttribute> =
         shouldImportAttributes && Object.keys(filteredProperties).length

--- a/plugin.json
+++ b/plugin.json
@@ -26,69 +26,6 @@
             "secret": true
         },
         {
-            "key": "importCampaigns",
-            "hint": "Do you want to import [Campaign](https://www.braze.com/docs/user_guide/engagement_tools/campaigns) analytics?",
-            "name": "Import Campaigns",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importCanvases",
-            "hint": "Do you want to import [Canvas](https://www.braze.com/docs/user_guide/engagement_tools/canvas) analytics?",
-            "name": "Import Canvas",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importCustomEvents",
-            "hint": "Do you want to import [Custom Events](https://www.braze.com/docs/user_guide/data_and_analytics/custom_data) analytics?",
-            "name": "Import Custom Events",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importFeeds",
-            "hint": "Do you want to import [News Feed](https://www.braze.com/docs/user_guide/engagement_tools/news_feed) analytics?",
-            "name": "Import News Feed Cards",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importKPIs",
-            "hint": "Do you want to import KPIs (Daily New Users, DAU, MAU, Daily Uninstalls)?",
-            "name": "Import KPIs",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importSegments",
-            "hint": "Do you want to import [Segment](https://www.braze.com/docs/user_guide/engagement_tools/segments) analytics?",
-            "name": "Import Segments",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
-            "key": "importSessions",
-            "hint": "Do you want to import daily Sessions?",
-            "name": "Import Sessions",
-            "type": "choice",
-            "default": "Yes",
-            "required": true,
-            "choices": ["Yes", "No"]
-        },
-        {
             "key": "eventsToExport",
             "hint": "A comma separated list of events you want to export to Braze. Leave empty to export no events.",
             "name": "Events to Export",
@@ -105,13 +42,12 @@
             "required": false
         },
         {
-            "key": "importUserAttributesInAllEvents",
-            "hint": "Will look for whitelisted user attributes to send to Braze in all events as opposed to only whitelisted events.",
-            "name": "Import User Attributes on All Events",
-            "type": "choice",
-            "default": "No",
-            "required": true,
-            "choices": ["Yes", "No"]
+            "key": "eventsToExportUserPropertiesFrom",
+            "hint": "A comma separated list of events you want to find user properties in to export to Braze. Leave empty to export no user properties.",
+            "name": "Events for user properties search",
+            "type": "string",
+            "default": "",
+            "required": false
         }
     ]
 }


### PR DESCRIPTION
More flexibility than just a all events / only filtered events ... now one can separately customize which events and from which events user properties are exported from.
Context: https://posthog.slack.com/archives/C0386ASS3TN/p1695149355428849?thread_ts=1692342517.071949&cid=C0386ASS3TN
